### PR TITLE
chore(rocks) bump lua-resty-acme to 0.4.0

### DIFF
--- a/kong-plugin-acme-dev-1.rockspec
+++ b/kong-plugin-acme-dev-1.rockspec
@@ -22,5 +22,5 @@ build = {
 }
 dependencies = {
   --"kong >= 1.2.0",
-  "lua-resty-acme >= 0.3.0"
+  "lua-resty-acme >= 0.4.0"
 }


### PR DESCRIPTION
use POST-as-GET pattern

Using GET to access order or challanges has been removed for
let's encrypt staging environment.

https://tools.ietf.org/html/rfc8555#section-6.3