### PR TITLE
tests(storage) change ttl tests to use 2 secs ttl instead of 1 sec

### DIFF
--- a/spec/02-kong_storage_spec.lua
+++ b/spec/02-kong_storage_spec.lua
@@ -92,7 +92,7 @@ for _, strategy in helpers.each_strategy() do
       local err, v
       it("returns no error", function()
 
-        err = a:set(key, "setttl", 1)
+        err = a:set(key, "setttl", 2)
         assert.is_nil(err)
 
         v, err = a:get(key)
@@ -101,7 +101,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("cleans up expired key", function()
-        ngx.sleep(1)
+        ngx.sleep(2)
 
         v, err = a:get(key)
         assert.is_nil(err)
@@ -139,7 +139,7 @@ for _, strategy in helpers.each_strategy() do
       local err, v
       it("returns no error", function()
 
-        err = a:add(key, "addttl", 1)
+        err = a:add(key, "addttl", 2)
         assert.is_nil(err)
 
         v, err = a:get(key)
@@ -148,7 +148,7 @@ for _, strategy in helpers.each_strategy() do
       end)
 
       it("cleans up expired key", function()
-        ngx.sleep(1)
+        ngx.sleep(2)
 
         v, err = a:get(key)
         assert.is_nil(err)


### PR DESCRIPTION
### Summary

Our CI has reported some flakiness on these tests, thus I decided that perhaps it helps to change the `ttl` from 1 sec to 2 sec on ttl related tests.