### PR TITLE
fix(api) rename to RESTful apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ $ curl https://mydomain.com -k
 
 # OR create from Admin API with version >= 0.2.4
 # User can also use this endpoint to force "renew" a certificate
-$ curl http://localhost:8001/acme/order -d host=mydomain.com
+$ curl http://localhost:8001/acme -d host=mydomain.com
 
 # Furthermore, it's possible to run sanity test on your Kong setup
 # before creating any certificate
-$ curl http://localhost:8001/acme/order -d host=mydomain.com -d test_http_challenge_flow=true
+$ curl http://localhost:8001/acme -d host=mydomain.com -d test_http_challenge_flow=true
 
 $ curl https://mydomain.com
 # Now gives you a valid Let's Encrypt certicate
@@ -82,7 +82,7 @@ It's also possible to actively trigger the renewal starting version 0.2.4. The f
 schedules renewal in background and return immediately.
 
 ```bash
-$ curl http://localhost:8001/acme/renew -XPOST
+$ curl http://localhost:8001/acme -XPATCH
 ```
 
 ### Plugin Config

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ $ curl https://mydomain.com -k
 
 # OR create from Admin API with version >= 0.2.4
 # User can also use this endpoint to force "renew" a certificate
-$ curl http://localhost:8001/acme/create -d host=mydomain.com
+$ curl http://localhost:8001/acme/order -d host=mydomain.com
 
-# Furthermore, it's possible to run sanity test before creating any certificate
-$ curl http://localhost:8001/acme/create -d host=mydomain.com -d test_only=1
+# Furthermore, it's possible to run sanity test on your Kong setup
+# before creating any certificate
+$ curl http://localhost:8001/acme/order -d host=mydomain.com -d test_http_challenge_flow=true
 
 $ curl https://mydomain.com
 # Now gives you a valid Let's Encrypt certicate

--- a/kong/plugins/acme/api.lua
+++ b/kong/plugins/acme/api.lua
@@ -14,7 +14,7 @@ local function find_plugin()
 end
 
 return {
-  ["/acme/create"] = {
+  ["/acme/order"] = {
     POST = function(self)
       local plugin, err = find_plugin()
       if err then
@@ -34,7 +34,7 @@ return {
         return kong.response.exit(400, { message = "port is not allowed in host" })
       end
 
-      if self.params.test_only then
+      if self.params.test_http_challenge_flow == "true" then
         local check_path = string.format("http://%s/.well-known/acme-challenge/", host)
         local httpc = http.new()
         local res, err = httpc:request_uri(check_path .. "x")

--- a/kong/plugins/acme/api.lua
+++ b/kong/plugins/acme/api.lua
@@ -14,7 +14,7 @@ local function find_plugin()
 end
 
 return {
-  ["/acme/order"] = {
+  ["/acme"] = {
     POST = function(self)
       local plugin, err = find_plugin()
       if err then
@@ -64,12 +64,10 @@ return {
       local msg = "certificate for host " .. host .. " is created"
       return kong.response.exit(201, { message = msg })
     end,
-  },
 
-  ["/acme/renew"] = {
-    POST = function()
+    PATCH = function()
       client.renew_certificate()
-      return kong.response.exit(202)
+      return kong.response.exit(202, { message = "Renewal process started successfully" })
     end,
   },
 }


### PR DESCRIPTION
Two endpoints exist at this time:

POST /acme create a certificate or test the Kong setup to create
this certificate.

PATCH /acme triggers the renewal timer, the plugin will decide which
certificates to renew.