### PR TITLE
fix(handler) increased plugin priority to run before all the auth

### DIFF
--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -12,7 +12,10 @@ local domains_matcher
 
 local LetsencryptHandler = {}
 
-LetsencryptHandler.PRIORITY = 999
+-- this has to be higher than auth plugins,
+-- otherwise acme-challenges endpoints may be blocked by auth plugins
+-- causing validation failures
+LetsencryptHandler.PRIORITY = 1007
 LetsencryptHandler.VERSION = "0.2.9"
 
 local function build_domain_matcher(domains)


### PR DESCRIPTION
plugins

This ensures the ACME validation endpoints
`/.well-known/acme-challenge/*` doesn't get blocked by auth plugins,
causing validation failures.

fixes #38