### PR TITLE
feat(apis) add endpoint to list certificates from storage

### DIFF
--- a/kong/plugins/acme/api.lua
+++ b/kong/plugins/acme/api.lua
@@ -29,6 +29,7 @@ end
 
 local function parse_certkey(certkey)
   local cert = x509.new(certkey.cert)
+  local key = cert:get_pubkey()
 
   local subject_name = cert:get_subject_name()
   local host = subject_name:find("CN")
@@ -43,6 +44,7 @@ local function parse_certkey(certkey)
     not_after = os.date("%Y-%m-%d %H:%M:%S", cert:get_not_after()),
     valid = cert:get_not_before() < ngx.time() and cert:get_not_after() > ngx.time(),
     serial_number = bn_to_hex(cert:get_serial_number()),
+    pubkey_type = key:get_key_type().sn,
   }
 end
 
@@ -128,7 +130,7 @@ return {
           return kong.response.exit(500, { message = err })
         end
         if not certkey then
-          kong.log.warn("[acme]", host, "is defined in renew_config but its cert and key is missing")
+          kong.log.warn("[acme]", host, " is defined in renew_config but its cert and key is missing")
         else
           certkey = parse_certkey(certkey)
           if not self.params.invalid_only or not certkey.valid then

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -276,7 +276,7 @@ local function load_certkey(conf, host)
   if err then
     return nil, "can't read SNI entity"
   elseif not sni_entity then
-    kong.log.warn("SNI ", host, " is not found in Kong database")
+    kong.log.info("SNI ", host, " is not found in Kong database")
     return
   end
 
@@ -352,6 +352,11 @@ local function renew_certificate_storage(conf)
       kong.log.err("can't read renew conf: ", err)
       goto renew_continue
     end
+    if not renew_conf then
+      kong.log.err("renew config key ",renew_conf_key, " is empty")
+      goto renew_continue
+    end
+
     renew_conf = cjson.decode(renew_conf)
 
     local host = renew_conf.host

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -429,12 +429,30 @@ local function load_certkey(conf, host)
   )
 end
 
+local function load_renew_hosts(conf)
+  local _, st, err = new_storage_adapter(conf)
+  if err then
+    return nil, err
+  end
+  local hosts, err = st:list(RENEW_KEY_PREFIX)
+  if err then
+    return nil, err
+  end
+
+  local data = {}
+  for i, host in ipairs(hosts) do
+    data[i] = string.sub(host, #RENEW_KEY_PREFIX + 1)
+  end
+  return data
+end
+
 return {
   new = new,
   create_account = create_account,
   update_certificate = update_certificate,
   renew_certificate = renew_certificate,
   store_renew_config = store_renew_config,
+  load_renew_hosts = load_renew_hosts,
   -- for dbless
   load_certkey = load_certkey,
 

--- a/kong/plugins/acme/handler.lua
+++ b/kong/plugins/acme/handler.lua
@@ -93,7 +93,7 @@ function LetsencryptHandler:certificate(conf)
     return
   end
 
-  local certkey, err = client.load_certkey(conf, host)
+  local certkey, err = client.load_certkey_cached(conf, host)
   if err then
     kong.log.warn("can't load cert and key from storage: ", err)
     return


### PR DESCRIPTION
New endpoints `/acme/certificates` and `/acme/certificates/:certificates` is added to allow user to peek
the certificate created by this plugin. When running Kong in database mode, those endpoint returns
certificate entity from Kong's database; in dbless mode, data from configured storage is returned.

Those endpoints are readonly, no update/delete is allowed at this time.
 
Sample output:

```
curl localhost:8001/acme/certificates |jq
{
  "data": [
    {
      "host": "x62357a8893cc.yyy.xxx",
      "not_before": "2020-09-08 11:01:53",
      "issuer_cn": "Fake LE Intermediate X1",
      "pubkey_type": "rsaEncryption",
      "valid": true,
      "serial_number": "FA:2E:45:37:38:3E:FC:AA:9A:45:7D:4F:20:F6:53:93:B0:26",
      "digest": "AF:20:65:2C:28:99:5A:5A:4A:2B:F2:F1:B3:FD:F3:35:3D:E9:D2:8A",
      "not_after": "2020-12-07 11:01:53"
    },
    {
      "host": "x62357a8893cc.yyy.xxx",
      "not_before": "2020-09-08 11:01:22",
      "issuer_cn": "Fake LE Intermediate X1",
      "pubkey_type": "rsaEncryption",
      "valid": true,
      "serial_number": "FA:CD:52:DA:AC:02:E3:10:2C:C3:5D:B4:48:A2:04:A8:73:BE",
      "digest": "84:58:D4:79:24:ED:22:AE:15:B1:55:99:4B:1C:5C:CD:12:B2:53:57",
      "not_after": "2020-12-07 11:01:22"
    },
    {
      "host": "x62357a8893cc.yyy.xxx"
      "not_before": "2020-09-08 11:05:08",
      "issuer_cn": "Fake LE Intermediate X1",
      "pubkey_type": "id-ecPublicKey",
      "valid": true,
      "serial_number": "FA:70:E5:71:2E:CA:04:84:E7:3F:00:3C:08:EC:5B:07:EF:E7",
      "digest": "67:9F:A8:D6:67:D5:03:B8:1F:A8:BE:C4:80:CC:2F:37:42:6D:18:3F",
      "not_after": "2020-12-07 11:05:08"
    }
  ]
}

curl localhost:8001/acme/certificates/x62357a8893cc.yyy.xxx |jq
{
  "data": {
    "host": "x62357a8893cc.yyy.xxx",
    "not_before": "2020-09-08 11:01:53",
    "issuer_cn": "Fake LE Intermediate X1",
    "pubkey_type": "rsaEncryption",
    "valid": true,
    "serial_number": "FA:2E:45:37:38:3E:FC:AA:9A:45:7D:4F:20:F6:53:93:B0:26",
    "digest": "AF:20:65:2C:28:99:5A:5A:4A:2B:F2:F1:B3:FD:F3:35:3D:E9:D2:8A",
    "not_after": "2020-12-07 11:01:53"
  }
}
```