### PR TITLE
chore(deps) bump lua-resty-acme to 0.6.x series

### DIFF
--- a/kong-plugin-acme-0.2.13-1.rockspec
+++ b/kong-plugin-acme-0.2.13-1.rockspec
@@ -24,5 +24,5 @@ build = {
 }
 dependencies = {
   --"kong >= 1.2.0",
-  "lua-resty-acme ~> 0.5"
+  "lua-resty-acme ~> 0.6"
 }


### PR DESCRIPTION
<a name="0.6.0"></a>
## [0.6.0] - 2021-02-19
### fix
- **autossl:** check if domain is set before trying to alter it ([#27](https://github.com/fffonion/lua-resty-acme/issues/27)) [fe36fc9](https://github.com/fffonion/lua-resty-acme/commit/fe36fc992b2d1c834eb8acbb8489f88f814653c4)
- **autossl:** returns error in update_cert_handler ([#25](https://github.com/fffonion/lua-resty-acme/issues/25)) [a7dff99](https://github.com/fffonion/lua-resty-acme/commit/a7dff99ef5dc30dcecbea534b124231c5b0aa9cf)
- **client:** BREAKING: do not force /directory at the end of api_url ([#31](https://github.com/fffonion/lua-resty-acme/issues/31)) [e4ea134](https://github.com/fffonion/lua-resty-acme/commit/e4ea134a0214f9df6f73fa8d31621cc96a382a6c)
- **client:** allow charset Content-Type header of ACME responses ([#30](https://github.com/fffonion/lua-resty-acme/issues/30)) [3a9ade6](https://github.com/fffonion/lua-resty-acme/commit/3a9ade62867d304835fb888f3dfbdc872afc133d)
- **openssl:** fix version import [6cb94be](https://github.com/fffonion/lua-resty-acme/commit/6cb94beb4b3911e28e55aa0b40ba547357e862e0)
