### PR TITLE
feat(*) sync upstream features including Vault K8S auth and preferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ config.storage_config|           | (See below)| Storage configs for each backend
 config.tos_accepted |            | `false`    | If you are using Let's Encrypt, you must set this to true to agree the [Terms of Service](https://letsencrypt.org/repository/).
 config.eab_kid      |            |            | External account binding (EAB) key id. You usually don't need to set this unless it is explicitly required by the CA.
 config.eab_hmac_key |            |            | External account binding (EAB) base64-encoded URL string of the HMAC key. You usually don't need to set this unless it is explicitly required by the CA.
+config.preferred_chain |            |            | Select a preferrable chain that has root CA issuer name matches the given value. If it's unconfigured or no such chain is matched, the default chain will be selected.
 
 `config.storage_config` is a table for all possible storage types, by default it is:
 ```json
@@ -131,14 +132,21 @@ config.eab_hmac_key |            |            | External account binding (EAB) b
             "timeout": 2000,
             "https": false,
             "tls_verify": true,
-            "tls_server_name": null
+            "tls_server_name": null,
+            "auth_method": "token",
+            "auth_pass": null,
+            "auth_role": null,
+            "jwt_path": null
         },
     }
 ```
 
 To configure storage type other than `kong`, please refer to [lua-resty-acme](https://github.com/fffonion/lua-resty-acme#storage-adapters).
 
-Note `tls_verify` and `tls_server_name` parameters for Vault are only supported from plugin version 0.2.7.
+Note `tls_verify` and `tls_server_name` parameters for Vault are only supported from plugin version 0.2.7;
+K8S auth configurations `auth_method`, `auth_pass`, `auth_role` and `jwt_path` for Vault are only
+supported from plugin version 0.3.0.
+
 
 Here's a sample declarative configuration with `redis` as storage:
 

--- a/kong-plugin-acme-0.2.14-1.rockspec
+++ b/kong-plugin-acme-0.2.14-1.rockspec
@@ -24,5 +24,5 @@ build = {
 }
 dependencies = {
   --"kong >= 1.2.0",
-  "lua-resty-acme ~> 0.6"
+  "lua-resty-acme ~> 0.7"
 }

--- a/kong/plugins/acme/client.lua
+++ b/kong/plugins/acme/client.lua
@@ -111,6 +111,7 @@ local function new(conf)
     storage_config = conf.storage_config[conf.storage],
     eab_kid = conf.eab_kid,
     eab_hmac_key = conf.eab_hmac_key,
+    preferred_chain = conf.preferred_chain,
   })
 end
 

--- a/kong/plugins/acme/schema.lua
+++ b/kong/plugins/acme/schema.lua
@@ -41,6 +41,11 @@ local VAULT_STORAGE_SCHEMA = {
   { token = { type = "string", }, },
   { tls_verify = { type = "boolean", default = true, }, },
   { tls_server_name = { type = "string" }, },
+  -- TODO: add default = "token", one_of = { "token", "kubernetes" } in 2.8 or 3.0
+  { auth_method = { type = "string" } },
+  { auth_path =  { type = "string" }, },
+  { auth_role =  { type = "string" }, },
+  { jwt_path =  { type = "string" }, },
 }
 
 local schema = {
@@ -101,6 +106,9 @@ local schema = {
             { consul = { type = "record", fields = CONSUL_STORAGE_SCHEMA, } },
             { vault = { type = "record", fields = VAULT_STORAGE_SCHEMA, } },
           },
+        }, },
+        { preferred_chain = {
+          type = "string",
         }, },
       },
     }, },


### PR DESCRIPTION
chain selection

This should go into 2.6. Rockspec needs to bumped to 0.3.x afterwards.